### PR TITLE
(#20) - print num skipped

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,7 +106,8 @@ module.exports = {
       return blacklist.indexOf(test) === -1;
     });
     if (skipping.length) {
-      console.log(colors.cyan('skipping:\n') + skipping.join('\n'));
+      console.log(colors.cyan('skipping ' + skipping.length + '/' + 
+        opts.tests.length + ' tests. skipped:\n') + skipping.join('\n'));
     }
     fs.writeFile(uri, addr, {encoding: 'utf8'}, function (err) {
       runTests(opts, callback);


### PR DESCRIPTION
I like the idea of being able to quantify in a single number how close we are to passing the entire CouchDB test suite. So I'd like to print out the number of tests skipped.